### PR TITLE
List plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/didierfranc/gatsby-plugin-google-fonts.git"
   },
-  "keywords": ["gatsby", "react", "google", "fonts"],
+  "keywords": ["gatsby", "gastby-plugin", "react", "google", "fonts"],
   "author": "Didier Franc <dev@didierfranc.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search.

https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310