### PR TITLE
Adds preconnect to fonts.gstatic.com

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -39,13 +39,13 @@ exports.onRenderBody = function(_ref, options) {
       key: 'google-fonts-preconnect',
       rel: 'preconnect',
       href: 'https://fonts.gstatic.com/',
-      crossorigin: 'anonymous'
+      crossOrigin: 'anonymous'
     }),
     _react2.default.createElement('link', {
       key: 'fonts',
       href: link,
       rel: 'stylesheet',
-      crossorigin: 'anonymous'
+      crossOrigin: 'anonymous'
     })
   ])
 }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -36,9 +36,16 @@ exports.onRenderBody = function(_ref, options) {
   var link = 'https://fonts.googleapis.com/css?family=' + getFonts(options) + getDisplay(options)
   setHeadComponents([
     _react2.default.createElement('link', {
+      key: 'google-fonts-preconnect',
+      rel: 'preconnect',
+      href: 'https://fonts.gstatic.com/',
+      crossorigin: 'anonymous'
+    }),
+    _react2.default.createElement('link', {
       key: 'fonts',
       href: link,
-      rel: 'stylesheet'
+      rel: 'stylesheet',
+      crossorigin: 'anonymous'
     })
   ])
 }


### PR DESCRIPTION
Also includes crossorigin="anonymous" to the CSS link tag cuz who needs
to send cookies to Google?


Here’s a reference for using `preconnect`: https://www.cdnplanet.com/blog/faster-google-webfonts-preconnect/